### PR TITLE
Meningkatan keterbacaan & navigasi pada card dan tag

### DIFF
--- a/src/components/CardItem.svelte
+++ b/src/components/CardItem.svelte
@@ -6,7 +6,16 @@
 </script>
 
 <style>
-
+  .card {
+    height: 100%;
+  }
+  .card .card-body {
+    padding-bottom: calc(1rem + 38px); /* card body padding + button height */
+  }
+  .card .btn--visit {
+    position: absolute;
+    bottom: 1rem;
+  }
 </style>
 
 <div class="col-md-4 col-sm-6 col-xs-12">
@@ -24,7 +33,7 @@
         href="{item.url}?utm_source=ajari-koding&utm_medium=website&utm_campaign=phpid"
         target="_blank"
         rel="noopener noreferrer"
-        class="btn btn-outline-primary">
+        class="btn btn-outline-primary btn--visit">
         Kunjungi
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/src/components/TagsCloud.svelte
+++ b/src/components/TagsCloud.svelte
@@ -21,6 +21,12 @@
 	outline: 0;
 	box-shadow: 0 0 0 .25rem rgba(13,110,253,.25);
 }
+.tag--unfocus {
+  opacity: .3;
+}
+.tag--unfocus:hover {
+  opacity: 1;
+}
 </style>
 
 <div class="mb-3">
@@ -32,7 +38,7 @@
 					data-toggle="button"
 					aria-pressed="{item.tag === activeTag}"
           type="button"
-          class="btn mr-2 mb-2 {item.tag === activeTag ? 'tag--active' : ''}"
+          class="btn mr-2 mb-2 {item.tag === activeTag ? 'tag--active' : ''} {activeTag !== '' && item.tag !== activeTag ? 'tag--unfocus' : ''}"
           style="background-color: {item.bg};color: {item.fg};"
           on:click={e => handleClick(e, item.tag)}>
           {item.tag}
@@ -44,7 +50,7 @@
 					data-toggle="button"
 					aria-pressed="{item.tag === activeTag}"
           type="button"
-          class="btn mr-2 mb-2 {item.classes} {item.tag === activeTag ? 'tag--active' : ''}"
+          class="btn mr-2 mb-2 {item.classes} {item.tag === activeTag ? 'tag--active' : ''} {activeTag !== '' && item.tag !== activeTag ? 'tag--unfocus' : ''}"
           on:click={e => handleClick(e, item.tag)}>
           {item.tag}
           <span class="badge bg-secondary">{allTags.withCount[item.tag]}</span>


### PR DESCRIPTION
**CARD STYLE**
Menurut saya, akan lebih mudah dalam keterbacaan apabila setiap _card_ memiliki tinggi yang sama. Kemudian untuk menu **Kunjungi** diletakkan pada posisi paling bawah, sehingga lebih memudahkan dalam navigasi.

Berikut contoh tampilan yang dihasilkan.

Tampilan pada layar laptop
<img width="1145" alt="Card Style Laptop" src="https://user-images.githubusercontent.com/11625690/85856913-08b8a800-b7e3-11ea-877d-90987260439a.png">

Tampilan pada layar HP
<img width="304" alt="Card Style HP" src="https://user-images.githubusercontent.com/11625690/85856952-1b32e180-b7e3-11ea-8279-2d49ec3d2736.png">

**TAG STYLE**
Awal mulanya saya membuka s.id/ajari-koding melalui perangkat HP, dan ketika mencoba klik di salah satu tag dengan asumsi itu untuk filtering, akan tetapi saya cukup bingung karena terlihat seperti tidak terjadi apa-apa.

Kemudian saya coba buka melalui laptop, dan saya baru sadar kalau itu benar-benar memang untuk filtering tag.

Berangkat dari itu, saya mencoba memperbaiki dari sisi pengalaman pengguna dengan membedakan tag yang sedang aktif dan tidak.

Berikut adalah contoh tampilan yang dihasilkan.

Tampilan pada layar laptop
<img width="714" alt="Active Tag Laptop" src="https://user-images.githubusercontent.com/11625690/85857887-df991700-b7e4-11ea-9d23-2d42b08937df.png">

Tampilan pada layar HP
<img width="307" alt="Screen Shot 2020-06-26 at 19 17 01" src="https://user-images.githubusercontent.com/11625690/85857918-ed4e9c80-b7e4-11ea-8d13-2ecf51dcf720.png">

Demikian, dan maaf atas kesalahan pada pull request sebelumnya.