### PR TITLE
Improve rating tooltip style

### DIFF
--- a/src/components/Rating.svelte
+++ b/src/components/Rating.svelte
@@ -26,11 +26,22 @@
     z-index: 1;
 
 		width: 150px;
-		bottom: 100%;
-		left: -8px;
+		bottom: calc(100% + 2px);
+		left: 1px;
   }
   .c-tooltip:hover .c-tooltiptext {
     visibility: visible;
+  }
+  .c-tooltip .c-tooltiptext::after {
+    content: '';
+    position: absolute;
+    width: 0;
+    height: 0;
+    border: 5px solid transparent;
+    border-top-color: #000;
+    transform: rotate(-90deg);
+    left: 0;
+    bottom: -5px;
   }
 </style>
 


### PR DESCRIPTION
Permisi, maaf mungkin perbaikan ini tidak terlalu signifikan, tapi serasa lebih enak melihatnya.

Berikut contoh hasilnya.
![Rating Tooltip Style](https://user-images.githubusercontent.com/11625690/85943432-4429b280-b95a-11ea-9544-31a69ec860d6.png)
